### PR TITLE
Health Check Implementation v1 complete. Implemented simple end server availability health checks for all end servers in a safe concurrent manner. 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM golang:1.22.1-alpine 
+
+RUN apk update && \
+    apk add --no-cache git
+RUN mkdir /app
+WORKDIR /app
+
+COPY . ./
+
+RUN go build -o binaryFile .
+
+CMD ["/app/binaryFile"]

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/Adarsh-Kmt/WebsocketReverseProxy
+
+go 1.22.1

--- a/main.go
+++ b/main.go
@@ -1,0 +1,26 @@
+package main
+
+import (
+	"sync"
+	"time"
+)
+
+func main() {
+
+	rp := InitializeReverseProxy()
+
+	rwm := sync.RWMutex{}
+
+	periodicFunc := func(rwm *sync.RWMutex) {
+
+		for {
+			time.Sleep(2 * time.Second)
+			rp.HealthCheck(rwm)
+		}
+
+	}
+
+	go periodicFunc(&rwm)
+
+	time.Sleep(10000 * time.Second)
+}

--- a/reverse_proxy.go
+++ b/reverse_proxy.go
@@ -1,0 +1,92 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"sync"
+
+	"github.com/Adarsh-Kmt/WebsocketReverseProxy/types"
+)
+
+type ReverseProxy struct {
+	EndServerPool          []string
+	HealthyEndServerPool   []string
+	UnhealthyEndServerPool []string
+	HESPMutex              *sync.Mutex     // mutex used to write to healthy end server pool.
+	UESPMutex              *sync.Mutex     // mutex used to write to unhealthy end server pool.
+	TESWaitGroup           *sync.WaitGroup // wait group for TestEndServer go routines.
+}
+
+func InitializeReverseProxy() *ReverseProxy {
+
+	return &ReverseProxy{EndServerPool: []string{"es1_hc:8080", "es2_hc:8080", "es3_hc:8080"},
+		HealthyEndServerPool:   make([]string, 3),
+		UnhealthyEndServerPool: make([]string, 0),
+		HESPMutex:              &sync.Mutex{},
+		UESPMutex:              &sync.Mutex{}}
+}
+
+func (rp *ReverseProxy) HealthCheck(RWMutex *sync.RWMutex) {
+
+	RWMutex.Lock()
+	defer RWMutex.Unlock()
+
+	rp.TESWaitGroup = &sync.WaitGroup{}
+
+	hesPool := make([]string, 0, len(rp.EndServerPool))
+	uesPool := make([]string, 0, len(rp.EndServerPool))
+
+	rp.HealthyEndServerPool = hesPool
+	rp.UnhealthyEndServerPool = uesPool
+
+	for _, es := range rp.EndServerPool {
+
+		rp.TESWaitGroup.Add(1)
+		go rp.TestEndServer(es)
+	}
+
+	rp.TESWaitGroup.Wait()
+
+	log.Printf("healthy end server pool : %s ", rp.HealthyEndServerPool)
+	log.Printf("unhealthy end server pool : %s", rp.UnhealthyEndServerPool)
+
+}
+func (rp *ReverseProxy) TestEndServer(esAddress string) error {
+
+	defer rp.TESWaitGroup.Done()
+
+	response, err := http.Get(fmt.Sprintf("http://" + esAddress + "/healthCheck"))
+
+	if err != nil {
+		log.Println(esAddress + " health check error: " + err.Error())
+
+		rp.UESPMutex.Lock()
+		rp.UnhealthyEndServerPool = append(rp.UnhealthyEndServerPool, esAddress)
+		rp.UESPMutex.Unlock()
+
+		return err
+	}
+
+	var hcr types.HealthCheckResponse
+	respBody, err := io.ReadAll(response.Body)
+	json.Unmarshal(respBody, &hcr)
+
+	if err != nil {
+		log.Println("error while json decoding health check response: " + err.Error())
+
+		rp.UESPMutex.Lock()
+		rp.UnhealthyEndServerPool = append(rp.UnhealthyEndServerPool, esAddress)
+		rp.UESPMutex.Unlock()
+
+		return err
+	}
+	fmt.Printf("response status received from %s : %d\n", esAddress, hcr.Status)
+
+	rp.HESPMutex.Lock()
+	rp.HealthyEndServerPool = append(rp.HealthyEndServerPool, esAddress)
+	rp.HESPMutex.Unlock()
+	return nil
+}

--- a/types/response.go
+++ b/types/response.go
@@ -1,0 +1,5 @@
+package types
+
+type HealthCheckResponse struct {
+	Status int `json:"status"`
+}


### PR DESCRIPTION
HealthCheck function spawns a TestEndServer go routine for each end server in the EndServerPool slice, to perform health checks concurrently. Once an end server responds (or does not respond), it is added into a HealthyEndServerPool or UnhealthyEndServerPool  slice accordingly, using mutex locks for each list, ensuring synchronization. The HealthyEndServerPool and UnhealthyEndServerPool are empty at the beginning of every health check.