### PR TITLE
Health Check Implementation v2 complete. 

### DIFF
--- a/config.ini
+++ b/config.ini
@@ -1,19 +1,21 @@
 [frontend]
-host=rp_v6
+host=rp_v7
 port=8084
 
 [websocket]
+
 server1=es1_hc:8080
 server2=es2_hc:8080
 server3=es3_hc:8080
 
 [http]
+
 server1_addr=es1_hc:8080
-server1_max_workers=10
+server1_max_workers=20
 server1_worker_timeout=3
 server2_addr=es2_hc:8080
-server2_max_workers=10
+server2_max_workers=20
 server2_worker_timeout=3
 server3_addr=es3_hc:8080
-server3_max_workers=10
+server3_max_workers=20
 server3_worker_timeout=3

--- a/server/http_server.go
+++ b/server/http_server.go
@@ -54,7 +54,7 @@ func InitializeHTTPServer(serverAddr string, serverId int, workerTimeout int, ma
 	hs := HTTPServer{
 		Addr:             serverAddr,
 		ServerId:         serverId,
-		JobChannel:       make(chan Job, 3),
+		JobChannel:       make(chan Job, 10),
 		Logger:           log.New(os.Stdout, fmt.Sprintf("HTTP SERVER %d :     ", serverId), 0),
 		WorkerTimeout:    workerTimeout,
 		MaxWorkerCount:   maxWorkerCount,
@@ -96,6 +96,7 @@ func ConfigureHTTPServers(httpSection ini.Section) ([]HTTPServer, error) {
 
 		val := httpSection[key]
 		// Only process keys with the prefix "server"
+
 		if !strings.HasPrefix(key, "server") {
 			return nil, fmt.Errorf("format for http section:\n\n[http]\nserver{number}_{config_name}={config}")
 		}


### PR DESCRIPTION
- TestHTTPServer/TestWebsocketServer go routines, use 2 separate channels to communicate wether a server is healthy/unhealthy.
- HealthCheck go routine collects info about all servers, then uses the write lock to write to HealthyServerPool list. 
- Used request timeouts for health checks to prevent convoy effect.
- Locking the list after performing health check on all servers, reduces the time taken to service requests, and allows health checks to occur simultaneously.